### PR TITLE
Set up 404 and skeleton lesson routes

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+const FourOhFour = () => {
+  return (
+    <div>
+      <h1>404</h1>
+      <Link href="/">
+        <a>Go back home</a>
+      </Link>
+    </div>
+  );
+};
+
+export default FourOhFour;

--- a/src/pages/learn/[...lesson].js
+++ b/src/pages/learn/[...lesson].js
@@ -1,0 +1,10 @@
+import { useRouter } from 'next/router';
+
+const Lesson = () => {
+  const router = useRouter();
+  const { asPath } = router;
+
+  return <p>Lesson: {asPath}</p>;
+};
+
+export default Lesson;


### PR DESCRIPTION
This adds:
- A 404 page
- A skeleton for a dynamic route so that we can navigate to `/learn/mission`, `/learn/task`, or `/learn/mission/task` (I call the file "lesson" as a catchall but that can easily be changed)

![routingphil](https://user-images.githubusercontent.com/1454517/92415399-8b2be500-f10d-11ea-9ab3-3ddaa86045c3.gif)
