### PR TITLE
fix (#216): remove extra layout padding on mobile

### DIFF
--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -35,6 +35,5 @@
 @media screen and (max-width: 1100px) {
   .main {
     margin: 0;
-    padding: 10px 20px;
   }
 }


### PR DESCRIPTION
Closes #216 