### PR TITLE
feat: debounce chart resize & make it sturdier

### DIFF
--- a/src/components/UserActivityGraph.js
+++ b/src/components/UserActivityGraph.js
@@ -1,21 +1,21 @@
-import styles from './UserActivityGraph.module.css';
-import { AreaChart } from 'react-chartkick';
-import { useUserState } from 'src/context/user';
-import 'chart.js';
 import { useEffect, useState } from 'react';
+import debounce from 'lodash/debounce';
+import { AreaChart } from 'react-chartkick';
+import 'chart.js';
+import { useUserState } from 'src/context/user';
+import styles from './UserActivityGraph.module.css';
 
 function UserActivityGraph() {
   const { user } = useUserState();
 
   const [opts, setOpts] = useState({
     title: 'Videos Watched',
-    width: '600px',
+    width: 'inherit',
     height: '200px',
     points: false,
   });
 
-  const onResize = () => {
-    const activityCard = document.querySelector('#user-activity-card');
+  const onResize = (activityCard) => {
     setOpts({
       ...opts,
       width: `${activityCard.clientWidth - 100}px`,
@@ -23,11 +23,13 @@ function UserActivityGraph() {
   };
 
   useEffect(() => {
-    onResize();
-    window.addEventListener('resize', onResize);
+    const activityCard = document.querySelector('#user-activity-card');
+    const handleResize = debounce(() => onResize(activityCard), 250);
+
+    window.addEventListener('resize', handleResize);
 
     return () => {
-      window.removeEventListener('resize', onResize);
+      window.removeEventListener('resize', handleResize);
     };
   }, []);
 


### PR DESCRIPTION
realized i should probably debounce and cleaned up some other things in the process

1. previously we were re-querying for the activitycard on every resize, now we just get it in the useEffect and pass it in
2. default width to inherit the parent's width