### PR TITLE
feat: auto-generate posters

### DIFF
--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -124,6 +124,11 @@ const VideoPlayer = ({ emitStageComplete, publicId, poster, title }) => {
   // leave off the format so we can use both webm and mp4 below
   const url = `${urlBase}/${dims}/${video}/${titleCard}/explorers/bumper`;
 
+  // use some of the same techniques to create a poster image with the title
+  const videoPoster =
+    poster ??
+    `${urlBase}/${dims},q_auto,f_auto,so_0/${titleText}/explorers/explorers-intro.jpg`;
+
   return (
     <video
       controls
@@ -131,7 +136,7 @@ const VideoPlayer = ({ emitStageComplete, publicId, poster, title }) => {
       id="lesson-video"
       ref={ref}
       className={styles.video}
-      poster={poster}
+      poster={videoPoster}
     >
       <source src={`${url}.webm`} type="video/webm" />
       <source src={`${url}.mp4`} type="video/mp4" />


### PR DESCRIPTION
new autogenerated posters look like the intro video: https://deploy-preview-317--jamstack-explorers.netlify.app/learn/angular-in-the-jamstack/intro

<img width="1392" alt="Screen Shot 2020-11-14 at 10 54 47 AM" src="https://user-images.githubusercontent.com/163561/99154859-d27fa600-2667-11eb-8899-853f9cf91212.png">


**NOTE:** this _only_ show up if you don't set a poster for the stage in Sanity

closes #316