### PR TITLE
feat: add description for videos in Sanity to discourage custom posters

### DIFF
--- a/backend/schemas/video.js
+++ b/backend/schemas/video.js
@@ -33,6 +33,8 @@ export default {
     {
       name: 'coverImage',
       title: 'Cover Image',
+      description:
+        'Leave this blank to have a poster auto-generated. In most cases you SHOULD let this auto-generate.',
       type: 'image',
     },
     {


### PR DESCRIPTION
I updated the Sanity schema to let people know posters are auto-generated and can be — but probably shouldn't be — overridden

re #316