### PR TITLE
Make "explorers" smaller and push footer up

### DIFF
--- a/src/components/ChonkyFooter.module.css
+++ b/src/components/ChonkyFooter.module.css
@@ -17,11 +17,14 @@
   text-orientation: upright;
   text-transform: uppercase;
   letter-spacing: 0.2rem;
+  font-size: 80%;
+  opacity: 0.6;
 }
 
 @media screen and (min-width: 900px) {
   .astronaut {
     margin-left: 100px;
+    margin-top: -100px;
   }
 }
 


### PR DESCRIPTION
Based on good feedback from @tzmanics, trying to improve the chonky footer:

Before:
<img width="1464" alt="CleanShot 2020-11-14 at 14 46 14@2x" src="https://user-images.githubusercontent.com/2281088/99157713-b4766d80-2688-11eb-8ba0-55f2ab712035.png">

After:
<img width="1344" alt="CleanShot 2020-11-14 at 14 45 47@2x" src="https://user-images.githubusercontent.com/2281088/99157718-bf310280-2688-11eb-88a5-2b71aedb38a8.png">

It especially looks better at the top of the page.