### PR TITLE
prevent downloads on lesson videos

### DIFF
--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -132,6 +132,8 @@ const VideoPlayer = ({ emitStageComplete, publicId, poster, title }) => {
   return (
     <video
       controls
+      controlsList="nodownload"
+      onContextMenu={(e) => e.preventDefault()}
       key={publicId}
       id="lesson-video"
       ref={ref}


### PR DESCRIPTION
fixes https://github.com/netlify/explorers/issues/320

oncontextmenu prevents right click -> save