### PR TITLE
fix (#398): remove extra min-width

### DIFF
--- a/src/components/Layout.module.css
+++ b/src/components/Layout.module.css
@@ -14,7 +14,6 @@
   width: 100%;
   height: 100%;
   min-height: 100vh;
-  min-width: 100vw;
   background: url(@public/page-bk.svg) no-repeat center bottom #000;
   background-size: cover;
   padding-bottom: 4rem;


### PR DESCRIPTION
Closes #398

This removes the additional overflow which was giving us a horizontal scrollbar on all pages.

Tested across the site in a variety of screen widths (desktop) on:

- chrome
- firefox
- safari