### PR TITLE
fix (#518): restore single author to course

### DIFF
--- a/src/components/UserMissionInfo.js
+++ b/src/components/UserMissionInfo.js
@@ -16,7 +16,7 @@ function UserMissionInfo({ mission }) {
         </p>
       </div>
       <div className={styles.instructor}>
-        <p>{mission.instructors[0]}</p>
+        <p>{mission.instructor}</p>
       </div>
       <div className={styles.tracker}>
         <Tracker progress={mission.progress} />


### PR DESCRIPTION
This is a fix to restore the profile page. It should be taking in an array of instructors, but the fix for that will take longer than is worth spending since the entire page is broken. Proposing to revert it back to single author on the User Profile page until we figure out how to render out however many number of authors is on a course (currently max 2).